### PR TITLE
Handling Expired Id and Access token, when there is still a next-auth session

### DIFF
--- a/askjiffy-ui/middleware.ts
+++ b/askjiffy-ui/middleware.ts
@@ -1,0 +1,2 @@
+export { auth as middleware } from "@/lib/auth/authConfig" //https://authjs.dev/getting-started/session-management/protecting
+

--- a/askjiffy-ui/src/components/ui/chat/newChatPage.tsx
+++ b/askjiffy-ui/src/components/ui/chat/newChatPage.tsx
@@ -9,7 +9,7 @@ import { UseChatInputContext } from "@/contexts/ChatHistoryContext";
 export default function NewChatPage(){
     
     const {data : session} = useSession();
-    const {data:userProfile, isLoading, isError} = useGetProfile();
+    const {data:userProfile, isLoading, isError, error} = useGetProfile();
     
 
     /*
@@ -23,7 +23,7 @@ export default function NewChatPage(){
     if(!session?.user){
         return(
             <div>
-                Unauthenticated
+                No Next Auth Session
             </div>
         );
     }
@@ -41,7 +41,7 @@ export default function NewChatPage(){
     if(isError){
         return(
             <div>
-                Unauthenticated
+                {error.message}
             </div>
         );
     }

--- a/askjiffy-ui/src/lib/auth/auth-utils.ts
+++ b/askjiffy-ui/src/lib/auth/auth-utils.ts
@@ -1,0 +1,45 @@
+import axios from "axios";
+import { JWT } from "next-auth/jwt";
+
+export async function refreshSecurityTokens(token : JWT) : Promise<JWT>{
+    try {
+        const urlSearchParams = new URLSearchParams({
+            client_id: process.env.AUTH_GOOGLE_ID!,
+            client_secret: process.env.AUTH_GOOGLE_SECRET!,
+            grant_type: "refresh_token",
+            refresh_token: token.refreshToken!
+        })
+
+        //request new IdToken from googleapis token endpoint
+        const url = "https://oauth2.googleapis.com/token"
+        
+        const response = await axios.post(url, urlSearchParams,{
+            headers:{
+               "Content-Type": "application/x-www-form-urlencoded" 
+            }
+        });
+        
+        const refreshedTokens = response.data;
+        
+        const newTokens = refreshedTokens as {
+            access_token: string,
+            id_token: string,
+            expires_in: number,
+            refresh_token?: string
+        }
+
+        return{
+            ...token,
+            accessToken: newTokens.access_token,
+            idToken: newTokens.id_token,
+            expiresAt: Math.floor(Date.now() / 1000 + newTokens.expires_in),
+            // some providers only issue refresh tokens once, so preserve old one if didn't recieve new one
+            refresh_token: newTokens.refresh_token ? newTokens.refresh_token : token.refreshToken
+        }
+    }
+    catch(error){
+        console.error("Error refreshing token", error);
+        token.error = "RefreshTokenError"
+        return token;
+    }
+}


### PR DESCRIPTION
added refresh token check + function to jwt callback ensuring that anytime session is checked (in the client) first check if the jwt has expired access and id tokens and refresh them with the refresh token if necessary