### PR TITLE
Feature: Chat History: Query And Component

### DIFF
--- a/askjiffy-ui/package.json
+++ b/askjiffy-ui/package.json
@@ -15,6 +15,7 @@
     "@radix-ui/react-label": "^2.1.2",
     "@radix-ui/react-navigation-menu": "^1.2.5",
     "@radix-ui/react-popover": "^1.1.11",
+    "@radix-ui/react-scroll-area": "^1.2.8",
     "@radix-ui/react-separator": "^1.1.2",
     "@radix-ui/react-slot": "^1.1.2",
     "@radix-ui/react-toast": "^1.2.11",

--- a/askjiffy-ui/pnpm-lock.yaml
+++ b/askjiffy-ui/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@radix-ui/react-popover':
         specifier: ^1.1.11
         version: 1.1.11(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-scroll-area':
+        specifier: ^1.2.8
+        version: 1.2.8(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-separator':
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -446,6 +449,9 @@ packages:
   '@radix-ui/number@1.1.0':
     resolution: {integrity: sha512-V3gRzhVNU1ldS5XhAPTom1fOIo4ccrjjJgmE+LI2h/WaFpHmx0MQApT+KZHnx8abG6Avtfcz4WoEciMnpFT3HQ==}
 
+  '@radix-ui/number@1.1.1':
+    resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
+
   '@radix-ui/primitive@1.1.1':
     resolution: {integrity: sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==}
 
@@ -672,6 +678,15 @@ packages:
 
   '@radix-ui/react-direction@1.1.0':
     resolution: {integrity: sha512-BUuBvgThEiAXh2DWu93XsT+a3aWrGqolGlqqw5VU1kG7p/ZH2cuDlM1sRLNnY3QcBS69UIz2mcKhMxDsdewhjg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-direction@1.1.1':
+    resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -988,6 +1003,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-primitive@2.1.2':
+    resolution: {integrity: sha512-uHa+l/lKfxuDD2zjN/0peM/RhhSmRjr5YWdk/37EnSv1nJ88uvG85DPexSm8HdFQROd2VdERJ6ynXbkCFi+APw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-progress@1.1.2':
     resolution: {integrity: sha512-u1IgJFQ4zNAUTjGdDL5dcl/U8ntOR6jsnhxKb5RKp5Ozwl88xKR9EqRZOe/Mk8tnx0x5tNUe2F+MzsyjqMg0MA==}
     peerDependencies:
@@ -1029,6 +1057,19 @@ packages:
 
   '@radix-ui/react-scroll-area@1.2.3':
     resolution: {integrity: sha512-l7+NNBfBYYJa9tNqVcP2AGvxdE3lmE6kFTBXdvHgUaZuy+4wGCL1Cl2AfaR7RKyimj7lZURGLwFO59k4eBnDJQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-scroll-area@1.2.8':
+    resolution: {integrity: sha512-K5h1RkYA6M0Sn61BV5LQs686zqBsSC0sGzL4/Gw4mNnjzrQcGSc6YXfC6CRFNaGydSdv5+M8cb0eNsOGo0OXtQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1090,6 +1131,15 @@ packages:
 
   '@radix-ui/react-slot@1.2.0':
     resolution: {integrity: sha512-ujc+V6r0HNDviYqIK3rW4ffgYiZ8g5DEHrGJVk4x7kTlLXRDILnKX9vAUYeIsLOoDpDJ0ujpqMkjH4w2ofuo6w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.2':
+    resolution: {integrity: sha512-y7TBO4xN4Y94FvcWIOIh18fM4R1A8S4q1jhoz4PNzOoHsFcN8pogcFmZrTYAm4F9VRUrWP/Mw7xSKybIeRI+CQ==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -3267,6 +3317,8 @@ snapshots:
 
   '@radix-ui/number@1.1.0': {}
 
+  '@radix-ui/number@1.1.1': {}
+
   '@radix-ui/primitive@1.1.1': {}
 
   '@radix-ui/primitive@1.1.2': {}
@@ -3489,6 +3541,12 @@ snapshots:
       '@types/react-dom': 19.0.4(@types/react@19.0.10)
 
   '@radix-ui/react-direction@1.1.0(@types/react@19.0.10)(react@19.0.0)':
+    dependencies:
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.10
+
+  '@radix-ui/react-direction@1.1.1(@types/react@19.0.10)(react@19.0.0)':
     dependencies:
       react: 19.0.0
     optionalDependencies:
@@ -3829,6 +3887,15 @@ snapshots:
       '@types/react': 19.0.10
       '@types/react-dom': 19.0.4(@types/react@19.0.10)
 
+  '@radix-ui/react-primitive@2.1.2(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.2(@types/react@19.0.10)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.10
+      '@types/react-dom': 19.0.4(@types/react@19.0.10)
+
   '@radix-ui/react-progress@1.1.2(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@radix-ui/react-context': 1.1.1(@types/react@19.0.10)(react@19.0.0)
@@ -3885,6 +3952,23 @@ snapshots:
       '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.0.10)(react@19.0.0)
       '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.0.10)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.10
+      '@types/react-dom': 19.0.4(@types/react@19.0.10)
+
+  '@radix-ui/react-scroll-area@1.2.8(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-presence': 1.1.4(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-primitive': 2.1.2(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.0.10)(react@19.0.0)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
@@ -3956,6 +4040,13 @@ snapshots:
       '@types/react': 19.0.10
 
   '@radix-ui/react-slot@1.2.0(@types/react@19.0.10)(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.10)(react@19.0.0)
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.10
+
+  '@radix-ui/react-slot@1.2.2(@types/react@19.0.10)(react@19.0.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.10)(react@19.0.0)
       react: 19.0.0
@@ -4466,6 +4557,7 @@ snapshots:
       dotenv: 16.4.7
       embla-carousel-react: 8.5.2(react@19.0.0)
       feather-icons-react: 0.8.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      jotai: 2.12.3(@types/react@19.0.10)(react@19.0.0)
       lucide-react: 0.483.0(react@19.0.0)
       next: 15.1.7(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       next-auth: 5.0.0-beta.25(next@15.1.7(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)

--- a/askjiffy-ui/src/app/api/user/getchats/route.ts
+++ b/askjiffy-ui/src/app/api/user/getchats/route.ts
@@ -13,17 +13,17 @@ export async function GET(req: Request) : Promise<Response>{
     }
     
     try{
-        const res = await axios.get(`${process.env.API_URL}/User/getprofile`,{
+        const res = await axios.get(`${process.env.API_URL}/Chat/getchatsessions`,{
             headers:{
                 Authorization: `Bearer ${token.idToken}`
             }
         });
-        
+
         //JSON.stringify ensures that the res.data object is serialized, this is necessary to map response to an api type
         return new Response(JSON.stringify(res.data), {status:200});
     }
     catch(error){
-        console.error('Error fetching profile:', error);
+        console.error('Error fetching chats:', error);
         
         // when catching an error, Typescript doesn't know what the type of error is, error is unknown cannot access properties like .response or .status
         // axios.isAxiosError(error) narrows the type first
@@ -39,8 +39,5 @@ export async function GET(req: Request) : Promise<Response>{
 
         //catch all for unknown errors 
         return new Response("Unexpected Error",{ status : 500});
-    }
-    
-
-   
+    }   
 }

--- a/askjiffy-ui/src/app/globals.css
+++ b/askjiffy-ui/src/app/globals.css
@@ -60,6 +60,27 @@
 	will-change: transform, opacity;
 }
 
+/* width */
+::-webkit-scrollbar {
+  width: 5px;
+}
+
+/* Track */
+::-webkit-scrollbar-track {
+  background: #f1f1f1;
+  height: 30px;
+}
+
+/* Handle */
+::-webkit-scrollbar-thumb {
+  background: #888;
+}
+
+/* Handle on hover */
+::-webkit-scrollbar-thumb:hover {
+  background: #555;
+}
+
 /* NavigationMenu.List wrapped in a div with relative positioning  https://github.com/radix-ui/primitives/discussions/1874 */
 nav > div:first-child {
 	display: contents

--- a/askjiffy-ui/src/components/app-sidebar.tsx
+++ b/askjiffy-ui/src/components/app-sidebar.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import { Calendar, Home, Inbox, Search, Settings, Wrench, BookText } from "lucide-react"
-import { useRouter } from 'next/navigation'
+import { Wrench, BookText } from "lucide-react"
+import { usePathname } from 'next/navigation'
 
 import {
   Sidebar,
@@ -14,6 +14,8 @@ import {
   SidebarMenuItem,
 } from "@/components/ui/sidebar"
 import Link from "next/link"
+import ChatHistory from "./ui/chat/chatHistory"
+import { useEffect, useState } from "react"
 
 // Menu items.
 const Links = [
@@ -29,8 +31,22 @@ const Links = [
   }
 ];
 export function AppSidebar() {
-  const router = useRouter();  
+  const pathname = usePathname();
+  const [isMounted, setIsMounted] = useState(false);
+  let showChatHistory = false;
+  
+  //empty dependency array runs once on component mount
+  useEffect( () => {
+    setIsMounted(true);
+  },[])
 
+  if(isMounted){
+    if(pathname === "/" || pathname.startsWith('/chat')){
+      showChatHistory = true;
+    }
+  }
+  
+ 
   return (
     <Sidebar>
       <SidebarContent>
@@ -53,6 +69,18 @@ export function AppSidebar() {
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>
+        { showChatHistory ? 
+          (<SidebarGroup>
+              <SidebarGroupLabel>Chat Session History</SidebarGroupLabel>
+              <SidebarGroupContent>
+                  <SidebarMenu>
+                    <ChatHistory />
+                  </SidebarMenu>
+              </SidebarGroupContent>
+            </SidebarGroup>)
+            : 
+            null
+        }
       </SidebarContent>
     </Sidebar>
   )

--- a/askjiffy-ui/src/components/ui/chat/chatHistory.tsx
+++ b/askjiffy-ui/src/components/ui/chat/chatHistory.tsx
@@ -1,0 +1,102 @@
+"use client"
+
+import { useGetChats } from "@/lib/queries/user/useGetChats";
+import { Separator } from "../separator";
+
+
+function cleanTitle(title: string){
+    const cleanTitle = title.replace(/[^a-zA-Z0-9 - $]/g, '');
+    return cleanTitle;
+}
+
+function categorizeChatSessions(
+    sessions: ChatSessionHistory[] | undefined
+): Record<string, ChatSessionHistory[]> {
+    const now = new Date();
+
+    const startOfToday = new Date(now);
+    startOfToday.setHours(0, 0, 0, 0);
+
+    //set bounds for start and end of yesterday
+    const startOfYesterday = new Date(startOfToday);
+    startOfYesterday.setDate(startOfToday.getDate() - 1);
+
+    const endOfYesterday = new Date(startOfYesterday);
+    endOfYesterday.setHours(23, 59, 59, 999);
+
+    const sevenDaysAgo = new Date(startOfToday);
+    sevenDaysAgo.setDate(startOfToday.getDate() - 6); //includes today as day 0
+
+    const categorized: Record<string, ChatSessionHistory[]> = {
+        "Today": [],
+        "Yesterday": [],
+        "Last 7 Days": [],
+        "A Long Time Ago": [],
+    };
+
+    sessions?.forEach(
+        (chatSessionHistory) => {
+            const lastUpdated = chatSessionHistory.updatedAt;
+
+            if (lastUpdated >= startOfToday){
+                categorized["Today"].push(chatSessionHistory);
+            }else if(lastUpdated >= startOfYesterday && lastUpdated <= endOfYesterday){
+                categorized["Yesterday"].push(chatSessionHistory);
+            }else if( lastUpdated >= sevenDaysAgo){
+                categorized["Last 7 Days"].push(chatSessionHistory);
+            }else{
+                categorized["A Long Time Ago"].push(chatSessionHistory);
+            }
+    })
+    
+    return categorized;
+}
+
+export default function ChatHistory(){
+    const {data: chatSessionHistory, isLoading, isError, error} = useGetChats();
+
+    if(isError){
+        return(
+            <div>Error: {error.message}</div>
+        )
+    }
+
+    if(isLoading){
+        return(
+            <div>Loading...</div>
+        )
+    }
+
+    const dateSortedChats = categorizeChatSessions(chatSessionHistory);
+
+    return(
+            <div className="px-4 py-2 h-full max-h-[650px] w-full rounded-md border overflow-y-auto">
+               {
+                    Object.entries(dateSortedChats).map(
+                        ([category, chatSessions]) => (
+                            <div key={`${category}-container`} className="h-full w-full">
+                                <h4 key={`${category}-header`} className="font-medium text-xs mb-2">{category}</h4>
+                                <div className="h-full max-h-[125px] overflow-y-auto mb-2 overflow-hidden " data-testid = {`${category}-container`} key={`${category}-container`}> 
+                                    <ul className="w-full h-full">
+                                        {
+                                            chatSessions.map((chat) => (
+                                                <li key={chat.id} className="my-2 hover:bg-gray-200 w-full rounded-md px-2 pt-1">
+                                                    {/* TODO: onClick handler */}
+                                                    <button type="submit" className="text-xs text-left rounded-md">
+                                                        {
+                                                            cleanTitle(chat.title)
+                                                        }
+                                                    </button>
+                                                </li>
+                                            ))
+                                        }
+                                    </ul>
+                                    <Separator className="my-2"/>
+                                </div>
+                            </div>
+                        )
+                    )
+                }
+            </div>
+    )
+}

--- a/askjiffy-ui/src/components/ui/scroll-area.tsx
+++ b/askjiffy-ui/src/components/ui/scroll-area.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import * as React from "react"
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
+
+import { cn } from "@/lib/utils"
+
+const ScrollArea = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
+>(({ className, children, ...props }, ref) => (
+  <ScrollAreaPrimitive.Root
+    ref={ref}
+    className={cn("relative overflow-hidden", className)}
+    {...props}
+  >
+    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+      {children}
+    </ScrollAreaPrimitive.Viewport>
+    <ScrollBar />
+    <ScrollAreaPrimitive.Corner />
+  </ScrollAreaPrimitive.Root>
+))
+ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName
+
+const ScrollBar = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>
+>(({ className, orientation = "vertical", ...props }, ref) => (
+  <ScrollAreaPrimitive.ScrollAreaScrollbar
+    ref={ref}
+    orientation={orientation}
+    className={cn(
+      "flex touch-none select-none transition-colors",
+      orientation === "vertical" &&
+        "h-full w-2.5 border-l border-l-transparent p-[1px]",
+      orientation === "horizontal" &&
+        "h-2.5 flex-col border-t border-t-transparent p-[1px]",
+      className
+    )}
+    {...props}
+  >
+    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
+  </ScrollAreaPrimitive.ScrollAreaScrollbar>
+))
+ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName
+
+export { ScrollArea, ScrollBar }

--- a/askjiffy-ui/src/lib/queries/user/useGetChats.ts
+++ b/askjiffy-ui/src/lib/queries/user/useGetChats.ts
@@ -1,0 +1,25 @@
+import { useQuery, UseQueryResult } from "@tanstack/react-query";
+import axios from "axios";
+
+const fetchChats = ():Promise<ChatSessionHistory[]> => axios.get("/api/user/getchats").then(
+    (response) => (
+        response.data.map(
+            (chat : any) => (
+                {
+                    ...chat,
+                    updatedAt: new Date(chat.updatedAt)
+                }
+            )
+        )
+    )
+);
+
+
+export function useGetChats(): UseQueryResult<ChatSessionHistory[],Error> 
+{
+    return useQuery({
+        queryKey: ['useGetChats'],
+        queryFn: fetchChats,
+        retry: 1
+    });    
+}

--- a/askjiffy-ui/src/types/api.d.ts
+++ b/askjiffy-ui/src/types/api.d.ts
@@ -1,17 +1,7 @@
-
-interface UserProfile{
-    id: number;
-    email: string;
-    role: UserRole;
-    chatHistory: UserChat[];
-    vehicles: Vehicle[];
-}
-
-interface UserChat{
+interface ChatSessionHistory{
     id: number;
     title: string;
-    CreatedAt: Date;
-    UpdatedAt: Date;
+    updatedAt: Date;   
 }
 
 interface Vehicle{
@@ -24,12 +14,6 @@ interface Vehicle{
     transmission? : Transmission | null;
     mileage?: int | null;
     //imageUrl: string
-}
-
-enum UserRole{
-    None = 0,
-    Mechanic = 1,
-    Moderator = 2,
 }
 
 enum QuestionType{


### PR DESCRIPTION
Added: useGetChats query hook, along with chatHistory sidebar component.  Only show chatHistory if the user is on the chat pages. TODO: add the chat/[id] page along, receive the streamed response from the backend to the front end. Invalidate the useGetChats query after creating new chat or rekindling old chat.